### PR TITLE
Add U+00AD (SOFT HYPHEN) to gremlins

### DIFF
--- a/Gremlins.py
+++ b/Gremlins.py
@@ -12,6 +12,7 @@ Globals
 # Zero-width characters
 SPACELESS_GREMLINS = str.join('', [
 	'\u007F-\u009F',
+	'\u00AD',
 	'\u200B-\u200F',
 	'\u2028-\u202E',
 	'\u2060-\u206F',


### PR DESCRIPTION
Hey! 
I added [U+00AD](https://en.wikipedia.org/wiki/Soft_hyphen) to the list of Gremlins. The soft hyphen is not visible unless the width of the display is small enough to warrant an hyphen. But Sublime being a text editor would not break the line anyway. 

See for example just before the @ : `thereisanhyphen­@somewhere.here`